### PR TITLE
Added MPU6050 reading example, added support for MPU6050 interrupts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 # BreezySTM32: A simple Arduino-like API for developing firmware on STM32-based flight controllers
 
 BreezySTM32 aims to provide a simple ("breezy") Application Programming Interface (API) for writing
-firmware on the ARM STM32F103 controller boards popular on toady's flight controllers 
+firmware on the ARM STM32F103 controller boards popular on toady's flight controllers
 (Naze32, Flip32, CC3D).
-As with the Arduino, you write a setup() function and a loop() function, and BreezySTM32 takes care of 
+As with the Arduino, you write a setup() function and a loop() function, and BreezySTM32 takes care of
 the rest, providing you with a C-like printf() statement, a SerialPort1 that you can read/write, and
-libraries for standard signals like analog voltage, PWM, UART, and I^2C.  (If you want 
-to use the Arduino IDE with your STM32 board, there are other 
+libraries for standard signals like analog voltage, PWM, UART, and I^2C.  (If you want
+to use the Arduino IDE with your STM32 board, there are other
 [tools](https://github.com/rogerclarkmelbourne/Arduino_STM32)
 to do this; my goal with BreezySTM32 was to provide a bare-bones C API for my favorite flight controllers.)
 
 To use BreezySTM32, you'll at minimum need to install the [GNU ARM toolchain](https://launchpad.net/gcc-arm-embedded).
-After that you can use whatever development tools you like to build your firmware.  I have found it easiest to avoid 
+After that you can use whatever development tools you like to build your firmware.  I have found it easiest to avoid
 IDE / debugging tools like Eclipse, sticking with simple
 makefiles for building / flashing, vim for editing, and printf() for debugging.  
 
@@ -19,19 +19,20 @@ To load new firmware, you should first disconnect the board from your computer, 
 and reconnect to your computer.  The Flip32 features through-hole soldering pads for the BOOT
 pins, so that is the board I've been using for development.  By pushing a two-pin jumper onto the pins,
 I avoid having to place a paper clip or tweezers across the pins while flashing. (The Baseflight firmware
-that I adapted to write BeezySTM32 uses the clever trick of 
+that I adapted to write BeezySTM32 uses the clever trick of
 [listening] (https://github.com/multiwii/baseflight/blob/master/src/serial.c#L878-L879)
 for a special reboot message, which you
 [send](https://github.com/multiwii/baseflight/blob/master/Makefile#L230)
 from your compute right before flashing. So if you've got a long-term project to work on, you might consider
 implementing something like that to avoid having to short the pins every time.)
 
-The BreezySTM32 examples directory includes the following use cases: 
+The BreezySTM32 examples directory includes the following use cases:
 <ul>
 <li> a simple LED blinker
 <li> a program that searches the board for I<sup>2</sup>C devices, reporting the addresses of any such devices found
-<li> a program that reads from the MaxBotix MB1242 I<sup>2</sup>C ultrasonic rangefinder and reports distances 
+<li> a program that reads from the MaxBotix MB1242 I<sup>2</sup>C ultrasonic rangefinder and reports distances
 in centimeters
+<li> a program that reads from the onboard MPU6050 Inertial Measurement Unit and reports acceleration in mm/s<sup>2</sup>, angular velocity in mrad/s and the time delay between measurements and the time to print to the screen in us.
 <li> a program that tests the SPI-based flash memory
 <li> a C++ program for blinking one of the LEDs
 </ul>
@@ -40,8 +41,6 @@ A makefile is included with each example,
 to show you how to start your own projects.  Type  <b><tt>make flash</tt></b> to flash the example to your board.
 
 If you find BreezySTM32 helpful, please consider donating
-to the [Baseflight](https://goo.gl/3tyFhz) or 
+to the [Baseflight](https://goo.gl/3tyFhz) or
 [Cleanflight](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=TSQKVT6UYKGL6)
 projects from which it is derived.
-
-

--- a/drv_mpu6050.h
+++ b/drv_mpu6050.h
@@ -21,6 +21,9 @@
 
 #pragma once
 
-void mpu6050_init(bool cuttingEdge, uint16_t * acc1G, float * gyroScale);
+extern volatile bool mpuDataReady;
+extern volatile uint32_t mpuMeasurementTime;
+
+void mpu6050_init(bool enableInterrupt, uint16_t * acc1G, float * gyroScale);
 void mpu6050_read_accel(int16_t *accData);
 void mpu6050_read_gyro(int16_t *gyroData);

--- a/examples/accelgyro/Makefile
+++ b/examples/accelgyro/Makefile
@@ -1,0 +1,169 @@
+###############################################################################
+# "THE BEER-WARE LICENSE" (Revision 42):
+# <msmith@FreeBSD.ORG> wrote this file. As long as you retain this notice you
+# can do whatever you want with this stuff. If we meet some day, and you think
+# this stuff is worth it, you can buy me a beer in return
+
+###############################################################################
+
+# Change this to wherever you put BreezySTM32
+BREEZY_DIR = ../../
+
+# Fill this out with source files for your specific project
+PROJECT_SRC = accelgyro.c
+
+###############################################################################
+
+# You probably shouldn't modify anything below here!
+
+TARGET		?= myproject
+
+# Compile-time options
+OPTIONS		?=
+
+# Debugger optons, must be empty or GDB
+DEBUG ?=
+
+# Serial port/Device for flashing
+SERIAL_DEVICE	?= /dev/ttyUSB0
+
+# Working directories
+ROOT		 = $(dir $(lastword $(MAKEFILE_LIST)))
+SRC_DIR		 = $(ROOT)
+CMSIS_DIR	 = $(BREEZY_DIR)/lib/CMSIS
+STDPERIPH_DIR	 = $(BREEZY_DIR)/lib/STM32F10x_StdPeriph_Driver
+OBJECT_DIR	 = $(ROOT)/obj
+BIN_DIR		 = $(ROOT)/obj
+
+myproject_SRC = $(BREEZY_DIR)/main.c \
+		   $(BREEZY_DIR)/startup_stm32f10x_md_gcc.S \
+		   $(BREEZY_DIR)/drv_gpio.c \
+		   $(BREEZY_DIR)/drv_i2c.c \
+		   $(BREEZY_DIR)/drv_system.c \
+		   $(BREEZY_DIR)/drv_serial.c \
+		   $(BREEZY_DIR)/drv_uart.c \
+		   $(BREEZY_DIR)/drv_timer.c \
+		   $(BREEZY_DIR)/printf.c \
+                   $(BREEZY_DIR)/drv_mpu6050.c \
+		   $(PROJECT_SRC) \
+		   $(CMSIS_SRC) \
+		   $(STDPERIPH_SRC)
+
+VPATH		:= $(SRC_DIR):$(SRC_DIR)/startups
+
+# Search path and source files for the CMSIS sources
+VPATH		:= $(VPATH):$(CMSIS_DIR)/CM3/CoreSupport:$(CMSIS_DIR)/CM3/DeviceSupport/ST/STM32F10x
+CMSIS_SRC	 = $(notdir $(wildcard $(CMSIS_DIR)/CM3/CoreSupport/*.c \
+			               $(CMSIS_DIR)/CM3/DeviceSupport/ST/STM32F10x/*.c))
+
+# Search path and source files for the ST stdperiph library
+VPATH		:= $(VPATH):$(STDPERIPH_DIR)/src
+STDPERIPH_SRC	 = $(notdir $(wildcard $(STDPERIPH_DIR)/src/*.c))
+
+###############################################################################
+# Things that might need changing to use different tools
+#
+
+# Tool names
+CC		 = arm-none-eabi-gcc -std=gnu99
+OBJCOPY	 = arm-none-eabi-objcopy
+
+#
+# Tool options.
+#
+INCLUDE_DIRS	 = $(SRC_DIR) \
+		   $(BREEZY_DIR) \
+		   $(STDPERIPH_DIR)/inc \
+		   $(CMSIS_DIR)/CM3/CoreSupport \
+		   $(CMSIS_DIR)/CM3/DeviceSupport/ST/STM32F10x \
+
+ARCH_FLAGS	 = -mthumb -mcpu=cortex-m3
+
+ifeq ($(DEBUG),GDB)
+OPTIMIZE	 = -Og
+
+else
+OPTIMIZE	 = -Os
+LTO_FLAGS	 = -flto -fuse-linker-plugin $(OPTIMIZE)
+endif
+
+DEBUG_FLAGS	 = -ggdb3
+
+CFLAGS		 = $(ARCH_FLAGS) \
+		   $(LTO_FLAGS) \
+		   $(addprefix -D,$(OPTIONS)) \
+		   $(addprefix -I,$(INCLUDE_DIRS)) \
+		   $(DEBUG_FLAGS) \
+		   -Wall -pedantic -Wextra -Wshadow -Wunsafe-loop-optimizations \
+		   -ffunction-sections \
+		   -fdata-sections \
+		   -DSTM32F10X_MD \
+		   -DUSE_STDPERIPH_DRIVER \
+		   -D$(TARGET)
+
+ASFLAGS		 = $(ARCH_FLAGS) \
+		   -x assembler-with-cpp \
+		   $(addprefix -I,$(INCLUDE_DIRS))
+
+LD_SCRIPT	 = $(BREEZY_DIR)/stm32_flash.ld
+LDFLAGS		 = -lm \
+		   -nostartfiles \
+		   --specs=nano.specs \
+		   -lc \
+		   -lnosys \
+		   $(ARCH_FLAGS) \
+		   $(LTO_FLAGS) \
+		   $(DEBUG_FLAGS) \
+		   -static \
+		   -Wl,-gc-sections,-Map,$(TARGET_MAP) \
+		   -T$(LD_SCRIPT)
+
+#
+# Things we will build
+#
+
+TARGET_HEX	 = $(BIN_DIR)/$(TARGET).hex
+TARGET_ELF	 = $(BIN_DIR)/$(TARGET).elf
+TARGET_OBJS	 = $(addsuffix .o,$(addprefix $(OBJECT_DIR)/$(TARGET)/,$(basename $($(TARGET)_SRC))))
+TARGET_MAP   = $(OBJECT_DIR)/$(TARGET).map
+
+# List of buildable ELF files and their object dependencies.
+# It would be nice to compute these lists, but that seems to be just beyond make.
+
+$(TARGET_HEX): $(TARGET_ELF)
+	$(OBJCOPY) -O ihex --set-start 0x8000000 $< $@
+
+$(TARGET_ELF):  $(TARGET_OBJS)
+	$(CC) -o $@ $^ $(LDFLAGS)
+
+MKDIR_OBJDIR = @mkdir -p $(dir $@)
+
+# Compile
+$(OBJECT_DIR)/$(TARGET)/%.o: %.c
+	$(MKDIR_OBJDIR)
+	@echo %% $(notdir $<)
+	@$(CC) -c -o $@ $(CFLAGS) $<
+
+# Assemble
+$(OBJECT_DIR)/$(TARGET)/%.o: %.S
+	$(MKDIR_OBJDIR)
+	@echo %% $(notdir $<)
+	@$(CC) -c -o $@ $(ASFLAGS) $< 
+
+clean:
+	rm -rf $(TARGET_HEX) $(TARGET_ELF) $(TARGET_OBJS) $(TARGET_MAP) obj
+
+flash_$(TARGET): $(TARGET_HEX)
+	stty -F $(SERIAL_DEVICE) raw speed 115200 -crtscts cs8 -parenb -cstopb -ixon
+	stm32flash -w $(TARGET_HEX) -v -g 0x0 -b 115200 $(SERIAL_DEVICE)
+
+flash: flash_$(TARGET)
+
+unbrick: $(TARGET_HEX)
+	stty -F $(SERIAL_DEVICE) raw speed 115200 -crtscts cs8 -parenb -cstopb -ixon
+	stm32flash -w $(TARGET_HEX) -v -g 0x0 -b 115200 $(SERIAL_DEVICE)
+
+listen:
+	miniterm.py $(SERIAL_DEVICE) 115200
+
+

--- a/examples/accelgyro/accelgyro.c
+++ b/examples/accelgyro/accelgyro.c
@@ -1,0 +1,37 @@
+/*
+   i2sniff.c : sniff and report I^2C devices 
+
+   Copyright (C) 2016 Simon D. Levy 
+
+   Adapted from https://github.com/multiwii/baseflight/blob/master/src/drv_adc.c
+
+   This file is part of BreezySTM32.
+
+   BreezySTM32 is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   BreezySTM32 is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with BreezySTM32.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <breezystm32.h>
+
+
+void setup(void)
+{
+  uint16_t acc1G;
+  float gyroScale;
+  mpu6050_init(true, &acc1G, &gyroScale);
+} 
+
+void loop(void)
+{
+
+}

--- a/examples/accelgyro/accelgyro.c
+++ b/examples/accelgyro/accelgyro.c
@@ -1,7 +1,7 @@
 /*
-   i2sniff.c : sniff and report I^2C devices 
+   i2sniff.c : sniff and report I^2C devices
 
-   Copyright (C) 2016 Simon D. Levy 
+   Copyright (C) 2016 Simon D. Levy
 
    Adapted from https://github.com/multiwii/baseflight/blob/master/src/drv_adc.c
 
@@ -24,14 +24,33 @@
 #include <breezystm32.h>
 
 
+uint16_t acc1G;
+float gyroScale;
+int16_t accel_data[3];
+int16_t gyro_data[3];
+
 void setup(void)
 {
-  uint16_t acc1G;
-  float gyroScale;
-  mpu6050_init(true, &acc1G, &gyroScale);
+    delay(500);
+    i2cInit(I2CDEV_2);
+    mpu6050_init(true, &acc1G, &gyroScale);
 } 
 
 void loop(void)
 {
-
+    int32_t accel_scale = (1000*9807)/acc1G;
+    float gyro_scale = gyroScale*1000000000.0;
+    if (mpuDataReady) {
+        mpuDataReady = false;
+        mpu6050_read_accel(accel_data);
+        mpu6050_read_gyro(gyro_data);
+        printf("%d\t%d\t%d\t%d\t%d\t%d\t%d\n",
+               ((int32_t)accel_data[0]*accel_scale)/1000, // prints in mm/s^s
+                ((int32_t)accel_data[1]*accel_scale)/1000,
+                ((int32_t)accel_data[2]*accel_scale)/1000,
+                (int32_t)((float)gyro_data[0]*gyro_scale), // prints in mrad/s
+                (int32_t)((float)gyro_data[1]*gyro_scale),
+                (int32_t)((float)gyro_data[2]*gyro_scale),
+                micros() - mpuMeasurementTime); // the time since the IMU measurement was taken in us
+    }
 }


### PR DESCRIPTION
I wrote a little example that reads from the accelerometer and gyro and prints the values to the terminal, more significantly, I added support for the external interrupt from the MPU6050.  I use this interrupt to calculate the amount of time in microseconds since the measurement was taken to print to the screen.  While this is sort of trivial in example form, it should be useful in future writing of estimators and controllers.

There is a little weirdness in handling the different ways that the interrupt pin is connected on different boards.  I tried to make it clear the changes that would be required to switch to a board other than the flip32, but it's not automatically handled.  I'm not sure how you would like to handle that sort of thing.