### PR TITLE
added board version handling to MPU6050

### DIFF
--- a/drv_mpu6050.h
+++ b/drv_mpu6050.h
@@ -24,6 +24,6 @@
 extern volatile bool mpuDataReady;
 extern volatile uint32_t mpuMeasurementTime;
 
-void mpu6050_init(bool enableInterrupt, uint16_t * acc1G, float * gyroScale);
+void mpu6050_init(bool enableInterrupt, uint16_t * acc1G, float * gyroScale, int boardVersion);
 void mpu6050_read_accel(int16_t *accData);
 void mpu6050_read_gyro(int16_t *gyroData);

--- a/examples/accelgyro/accelgyro.c
+++ b/examples/accelgyro/accelgyro.c
@@ -31,7 +31,7 @@ void setup(void)
 {
     delay(500);
     i2cInit(I2CDEV_2);
-    mpu6050_init(true, &acc1G, &gyroScale);
+    mpu6050_init(true, &acc1G, &gyroScale, 5);
 } 
 
 void loop(void)


### PR DESCRIPTION
I have added some capability to switch between board versions.  I added an argument to mpu6050_init, rather than using macros, which I think is a bit more flexible, and makes Breezy easier to use as a library.

Let me know what you think.