### PR TITLE
Airspeed

### DIFF
--- a/breezystm32.h
+++ b/breezystm32.h
@@ -40,6 +40,7 @@ along with BreezySTM32.  If not, see <http://www.gnu.org/licenses/>.
 #include "drv_gpio.h"
 #include "drv_m25p16.h"
 #include "drv_flashfs.h"
+#include "drv_ms4525.h"
 
 #include "printf.h"
 

--- a/drv_ms4525.c
+++ b/drv_ms4525.c
@@ -1,9 +1,24 @@
-#include <stdint.h>
-#include <stdbool.h>
+/*
+   drv_ms4525.c : driver for MS4525 differential pressure sensor
+
+   This file is part of BreezySTM32.
+
+   BreezySTM32 is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   BreezySTM32 is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with BreezySTM32.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 
 #include <breezystm32.h>
-
-#include "drv_ms4525.h"
 
 // MS4525 address 0x28 for most common version
 #define MS4525_ADDR   0x28

--- a/drv_ms4525.c
+++ b/drv_ms4525.c
@@ -1,0 +1,49 @@
+#include <stdint.h>
+#include <stdbool.h>
+
+#include <breezystm32.h>
+
+#include "drv_ms4525.h"
+
+// MS4525 address 0x28 for most common version
+#define MS4525_ADDR   0x28
+#define STATUS_MASK   0x3F
+
+
+bool ms4525_detect(void)
+{
+    uint8_t buf[1];
+    return i2cRead(MS4525_ADDR, 0xFF, 1, buf);
+}
+
+void ms4525_init(void)
+{
+    ms4525_detect();
+}
+
+void ms4525_read(int16_t* velocity, int16_t* temp)
+{
+    int16_t data[2];
+    uint8_t buf[4];
+
+    i2cRead(MS4525_ADDR, 0xFF, 4, buf);
+
+    uint8_t status = (buf[0] >> 5); // first two bits are status bits
+    if(status == 0x00) // good data packet
+    {
+        data[0] = (int16_t)(((STATUS_MASK | buf[0]) << 8) | buf[1]);
+        data[1] = (int16_t)((buf[2] << 3) | (buf[3] >> 5));
+    }
+    else if(status == 0x02) // stale data packet
+    {
+        data[0] = (int16_t)(((STATUS_MASK | buf[0]) << 8) | buf[1]);
+        data[1] = (int16_t)((buf[2] << 3) | (buf[3] >> 5));
+    }
+    else
+    {
+        return;
+    }
+    *velocity = data[0];
+    *temp = data[1];
+    return;
+}

--- a/drv_ms4525.h
+++ b/drv_ms4525.h
@@ -1,6 +1,23 @@
-#pragma once
+/*
+   drv_ms4525.h : driver for MS4525 Differential Pressure Sensor
 
-#include "drv_i2c.h"
+   This file is part of BreezySTM32.
+
+   BreezySTM32 is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   BreezySTM32 is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with BreezySTM32.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
 
 bool ms4525_detect(void);
 void ms4525_init(void);

--- a/drv_ms4525.h
+++ b/drv_ms4525.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include "drv_i2c.h"
+
+bool ms4525_detect(void);
+void ms4525_init(void);
+void ms4525_read(int16_t* velocity, int16_t* temp);

--- a/examples/ms4525/Makefile
+++ b/examples/ms4525/Makefile
@@ -1,0 +1,170 @@
+###############################################################################
+# "THE BEER-WARE LICENSE" (Revision 42):
+# <msmith@FreeBSD.ORG> wrote this file. As long as you retain this notice you
+# can do whatever you want with this stuff. If we meet some day, and you think
+# this stuff is worth it, you can buy me a beer in return
+
+###############################################################################
+
+# Change this to wherever you put BreezySTM32
+BREEZY_DIR = ../../
+
+# Fill this out with source files for your specific project
+PROJECT_SRC = ms4525.c
+
+###############################################################################
+
+# You probably shouldn't modify anything below here!
+
+TARGET		?= myproject
+
+# Compile-time options
+OPTIONS		?=
+
+# Debugger optons, must be empty or GDB
+DEBUG ?=
+
+# Serial port/Device for flashing
+SERIAL_DEVICE	?= /dev/ttyUSB0
+
+# Working directories
+ROOT		 = $(dir $(lastword $(MAKEFILE_LIST)))
+SRC_DIR		 = $(ROOT)
+CMSIS_DIR	 = $(BREEZY_DIR)/lib/CMSIS
+STDPERIPH_DIR	 = $(BREEZY_DIR)/lib/STM32F10x_StdPeriph_Driver
+OBJECT_DIR	 = $(ROOT)/obj
+BIN_DIR		 = $(ROOT)/obj
+
+myproject_SRC = $(BREEZY_DIR)/main.c \
+		   $(BREEZY_DIR)/startup_stm32f10x_md_gcc.S \
+		   $(BREEZY_DIR)/drv_gpio.c \
+		   $(BREEZY_DIR)/drv_i2c.c \
+		   $(BREEZY_DIR)/drv_system.c \
+		   $(BREEZY_DIR)/drv_serial.c \
+		   $(BREEZY_DIR)/drv_uart.c \
+		   $(BREEZY_DIR)/drv_timer.c \
+		   $(BREEZY_DIR)/printf.c \
+           $(BREEZY_DIR)/drv_mpu6050.c \
+           $(BREEZY_DIR)/drv_ms4525.c \
+		   $(PROJECT_SRC) \
+		   $(CMSIS_SRC) \
+		   $(STDPERIPH_SRC)
+
+VPATH		:= $(SRC_DIR):$(SRC_DIR)/startups
+
+# Search path and source files for the CMSIS sources
+VPATH		:= $(VPATH):$(CMSIS_DIR)/CM3/CoreSupport:$(CMSIS_DIR)/CM3/DeviceSupport/ST/STM32F10x
+CMSIS_SRC	 = $(notdir $(wildcard $(CMSIS_DIR)/CM3/CoreSupport/*.c \
+			               $(CMSIS_DIR)/CM3/DeviceSupport/ST/STM32F10x/*.c))
+
+# Search path and source files for the ST stdperiph library
+VPATH		:= $(VPATH):$(STDPERIPH_DIR)/src
+STDPERIPH_SRC	 = $(notdir $(wildcard $(STDPERIPH_DIR)/src/*.c))
+
+###############################################################################
+# Things that might need changing to use different tools
+#
+
+# Tool names
+CC		 = arm-none-eabi-gcc -std=gnu99
+OBJCOPY	 = arm-none-eabi-objcopy
+
+#
+# Tool options.
+#
+INCLUDE_DIRS	 = $(SRC_DIR) \
+		   $(BREEZY_DIR) \
+		   $(STDPERIPH_DIR)/inc \
+		   $(CMSIS_DIR)/CM3/CoreSupport \
+		   $(CMSIS_DIR)/CM3/DeviceSupport/ST/STM32F10x \
+
+ARCH_FLAGS	 = -mthumb -mcpu=cortex-m3
+
+ifeq ($(DEBUG),GDB)
+OPTIMIZE	 = -Og
+
+else
+OPTIMIZE	 = -Os
+LTO_FLAGS	 = -flto -fuse-linker-plugin $(OPTIMIZE)
+endif
+
+DEBUG_FLAGS	 = -ggdb3
+
+CFLAGS		 = $(ARCH_FLAGS) \
+		   $(LTO_FLAGS) \
+		   $(addprefix -D,$(OPTIONS)) \
+		   $(addprefix -I,$(INCLUDE_DIRS)) \
+		   $(DEBUG_FLAGS) \
+		   -Wall -pedantic -Wextra -Wshadow -Wunsafe-loop-optimizations \
+		   -ffunction-sections \
+		   -fdata-sections \
+		   -DSTM32F10X_MD \
+		   -DUSE_STDPERIPH_DRIVER \
+		   -D$(TARGET)
+
+ASFLAGS		 = $(ARCH_FLAGS) \
+		   -x assembler-with-cpp \
+		   $(addprefix -I,$(INCLUDE_DIRS))
+
+LD_SCRIPT	 = $(BREEZY_DIR)/stm32_flash.ld
+LDFLAGS		 = -lm \
+		   -nostartfiles \
+		   --specs=nano.specs \
+		   -lc \
+		   -lnosys \
+		   $(ARCH_FLAGS) \
+		   $(LTO_FLAGS) \
+		   $(DEBUG_FLAGS) \
+		   -static \
+		   -Wl,-gc-sections,-Map,$(TARGET_MAP) \
+		   -T$(LD_SCRIPT)
+
+#
+# Things we will build
+#
+
+TARGET_HEX	 = $(BIN_DIR)/$(TARGET).hex
+TARGET_ELF	 = $(BIN_DIR)/$(TARGET).elf
+TARGET_OBJS	 = $(addsuffix .o,$(addprefix $(OBJECT_DIR)/$(TARGET)/,$(basename $($(TARGET)_SRC))))
+TARGET_MAP   = $(OBJECT_DIR)/$(TARGET).map
+
+# List of buildable ELF files and their object dependencies.
+# It would be nice to compute these lists, but that seems to be just beyond make.
+
+$(TARGET_HEX): $(TARGET_ELF)
+	$(OBJCOPY) -O ihex --set-start 0x8000000 $< $@
+
+$(TARGET_ELF):  $(TARGET_OBJS)
+	$(CC) -o $@ $^ $(LDFLAGS)
+
+MKDIR_OBJDIR = @mkdir -p $(dir $@)
+
+# Compile
+$(OBJECT_DIR)/$(TARGET)/%.o: %.c
+	$(MKDIR_OBJDIR)
+	@echo %% $(notdir $<)
+	@$(CC) -c -o $@ $(CFLAGS) $<
+
+# Assemble
+$(OBJECT_DIR)/$(TARGET)/%.o: %.S
+	$(MKDIR_OBJDIR)
+	@echo %% $(notdir $<)
+	@$(CC) -c -o $@ $(ASFLAGS) $< 
+
+clean:
+	rm -rf $(TARGET_HEX) $(TARGET_ELF) $(TARGET_OBJS) $(TARGET_MAP) obj
+
+flash_$(TARGET): $(TARGET_HEX)
+	stty -F $(SERIAL_DEVICE) raw speed 115200 -crtscts cs8 -parenb -cstopb -ixon
+	stm32flash -w $(TARGET_HEX) -v -g 0x0 -b 115200 $(SERIAL_DEVICE)
+
+flash: flash_$(TARGET)
+
+unbrick: $(TARGET_HEX)
+	stty -F $(SERIAL_DEVICE) raw speed 115200 -crtscts cs8 -parenb -cstopb -ixon
+	stm32flash -w $(TARGET_HEX) -v -g 0x0 -b 115200 $(SERIAL_DEVICE)
+
+listen:
+	miniterm.py $(SERIAL_DEVICE) 115200
+
+

--- a/examples/ms4525/ms4525.c
+++ b/examples/ms4525/ms4525.c
@@ -1,0 +1,47 @@
+/*
+   ms4525.c : Airpseed Measurement Values
+
+   Copyright (C) 2016 James Jackson
+
+   This file is part of BreezySTM32.
+
+   BreezySTM32 is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   BreezySTM32 is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with BreezySTM32.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <breezystm32.h>
+
+
+void setup(void)
+{
+    delay(500);
+    i2cInit(I2CDEV_2);
+}
+
+int16_t velocity;
+int16_t temp;
+
+void loop(void)
+{
+    if( ms4525_detect() )
+    {
+        ms4525_read(&velocity, &temp);
+        printf("velocity = %d, temp = %d\n", velocity, temp);
+    }
+    else
+    {
+        printf("no airspeed\n");
+    }
+    delay(10);
+}
+


### PR DESCRIPTION
This adds support for the MS4525 Airspeed sensor (commonly used on the PixHawk).

I have tested it on a rev4 and a rev5 board, and can confirm it works.