### PR TITLE
Fix MB1242 Init and error in mpu_6050

### DIFF
--- a/drv_mb1242.c
+++ b/drv_mb1242.c
@@ -58,7 +58,10 @@ static bool attempt_write(void)
 
 bool mb1242_init(void)
 {
-    return attempt_write() == 1;
+  // The only way to know if a sonar is attached is to try to get a reading (doesn't always ACK on i2c)
+  mb1242_poll();
+  delay(200);    // You have to wait 200 ms for the sensor to read
+  return (mb1242_poll > 0); // if you have a measurement, return true, otherwise, there was no sonar attached
 }
 
 int32_t mb1242_poll(void)

--- a/drv_mpu6050.c
+++ b/drv_mpu6050.c
@@ -214,7 +214,7 @@ void mpu6050_init(bool enableInterrupt, uint16_t * acc1G, float * gyroScale, int
 
     // All this just to set the value
     if (half)
-        *acc1G = 255 * 8;
+        *acc1G = 256 * 8;
 
     // 16.4 dps/lsb scalefactor for all Invensense devices
     *gyroScale = (4.0f / 16.4f) * (M_PI / 180.0f) * 0.000001f;
@@ -288,4 +288,3 @@ void mpu6050_register_interrupt_cb(void (*functionPtr)(void))
 {
   mpuInterruptCallbackPtr = functionPtr;
 }
-

--- a/examples/accelgyro/accelgyro.c
+++ b/examples/accelgyro/accelgyro.c
@@ -56,25 +56,16 @@ void loop(void)
         mpu6050_read_accel(accel_data);
         mpu6050_read_gyro(gyro_data);
         mpu6050_read_temperature(&temp_data);
-        printf("%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\n",
-               accel_scale,
-               (int32_t)gyro_scale,
-               accel_data[0],
-               accel_data[1],
-               accel_data[2],
-               gyro_data[0],
-               gyro_data[1],
-               gyro_data[2],
-               temp_data,
-               mpu_cb_time-prev_time); // the time since the previous IMU measurement was taken in us
-              //  ((int32_t)accel_data[0]*accel_scale)/1000, // prints in mm/s^s
-              //   ((int32_t)accel_data[1]*accel_scale)/1000,
-              //   ((int32_t)accel_data[2]*accel_scale)/1000,
-              //   (int32_t)((float)gyro_data[0]*gyro_scale), // prints in mrad/s
-              //   (int32_t)((float)gyro_data[1]*gyro_scale),
-              //   (int32_t)((float)gyro_data[2]*gyro_scale),
-              //   (int32_t)((temp_data/340.0 + 36.53)*1000),
-              //   mpu_cb_time-prev_time); // the time since the previous IMU measurement was taken in us
+        
+        printf("%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\n",
+              ((int32_t)accel_data[0]*accel_scale)/1000, // prints in mm/s^s
+              ((int32_t)accel_data[1]*accel_scale)/1000,
+              ((int32_t)accel_data[2]*accel_scale)/1000,
+              (int32_t)((float)gyro_data[0]*gyro_scale), // prints in mrad/s
+              (int32_t)((float)gyro_data[1]*gyro_scale),
+              (int32_t)((float)gyro_data[2]*gyro_scale),
+              (int32_t)((temp_data/340.0 + 36.53)*1000),
+              mpu_cb_time-prev_time); // the time since the previous IMU measurement was taken in us
     }
     else
     {

--- a/examples/accelgyro/accelgyro.c
+++ b/examples/accelgyro/accelgyro.c
@@ -43,8 +43,8 @@ void setup(void)
     delay(500);
     i2cInit(I2CDEV_2);
     mpu6050_register_interrupt_cb(&interruptCallback);
-    mpu6050_init(true, &acc1G, &gyroScale, 5);
-} 
+    mpu6050_init(true, &acc1G, &gyroScale, 2);
+}
 
 void loop(void)
 {
@@ -56,14 +56,28 @@ void loop(void)
         mpu6050_read_accel(accel_data);
         mpu6050_read_gyro(gyro_data);
         mpu6050_read_temperature(&temp_data);
-        printf("%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\n",
-               ((int32_t)accel_data[0]*accel_scale)/1000, // prints in mm/s^s
-                ((int32_t)accel_data[1]*accel_scale)/1000,
-                ((int32_t)accel_data[2]*accel_scale)/1000,
-                (int32_t)((float)gyro_data[0]*gyro_scale), // prints in mrad/s
-                (int32_t)((float)gyro_data[1]*gyro_scale),
-                (int32_t)((float)gyro_data[2]*gyro_scale),
-                (int32_t)((temp_data/340.0 + 36.53)*1000),
-                mpu_cb_time-prev_time); // the time since the previous IMU measurement was taken in us
+        printf("%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\n",
+               accel_scale,
+               (int32_t)gyro_scale,
+               accel_data[0],
+               accel_data[1],
+               accel_data[2],
+               gyro_data[0],
+               gyro_data[1],
+               gyro_data[2],
+               temp_data,
+               mpu_cb_time-prev_time); // the time since the previous IMU measurement was taken in us
+              //  ((int32_t)accel_data[0]*accel_scale)/1000, // prints in mm/s^s
+              //   ((int32_t)accel_data[1]*accel_scale)/1000,
+              //   ((int32_t)accel_data[2]*accel_scale)/1000,
+              //   (int32_t)((float)gyro_data[0]*gyro_scale), // prints in mrad/s
+              //   (int32_t)((float)gyro_data[1]*gyro_scale),
+              //   (int32_t)((float)gyro_data[2]*gyro_scale),
+              //   (int32_t)((temp_data/340.0 + 36.53)*1000),
+              //   mpu_cb_time-prev_time); // the time since the previous IMU measurement was taken in us
+    }
+    else
+    {
+      delayMicroseconds(100);
     }
 }

--- a/examples/mb1242/mb1242read.c
+++ b/examples/mb1242/mb1242read.c
@@ -23,12 +23,21 @@
 
 #include <breezystm32.h>
 
+
+static bool sonar_present = false;
+int16_t first_read;
 void setup(void)
 {
     i2cInit(I2CDEV_2);
-} 
+    delay(500);
+    sonar_present = mb1242_init();
+}
 
 void loop(void)
 {
+ if(sonar_present)
     printf("%d\n", mb1242_poll());
+  else
+    printf("no sonar\n");
+ delay(100);
 }


### PR DESCRIPTION
I modified the `mb1242_init()` function to be more like the PX4 function, so it can more reliably identify if a sonar is attached.

I also fixed an issue in the `mpu6050_init()` function where it would calculate the wrong value of `acc1G` for some revisions of the MPU6050.