### PR TITLE
Gyro scale factor

### DIFF
--- a/drv_mpu6050.c
+++ b/drv_mpu6050.c
@@ -217,7 +217,7 @@ void mpu6050_init(bool enableInterrupt, uint16_t * acc1G, float * gyroScale, int
         *acc1G = 256 * 8;
 
     // 16.4 dps/lsb scalefactor for all Invensense devices
-    *gyroScale = (4.0f / 16.4f) * (M_PI / 180.0f) * 0.000001f;
+    *gyroScale = (1.0f / 16.4f) * (M_PI / 180.0f);
 
     // MPU_INT output on rev5+ hardware (PC13)
     if (enableInterrupt) {
@@ -270,9 +270,9 @@ void mpu6050_read_gyro(int16_t *gyroData)
 
     mpuReadRegisterI2C(MPU_RA_GYRO_XOUT_H, buf, 6);
 
-    gyroData[0] = (int16_t)((buf[0] << 8) | buf[1]) / 4;
-    gyroData[1] = (int16_t)((buf[2] << 8) | buf[3]) / 4;
-    gyroData[2] = (int16_t)((buf[4] << 8) | buf[5]) / 4;
+    gyroData[0] = (int16_t)((buf[0] << 8) | buf[1]);
+    gyroData[1] = (int16_t)((buf[2] << 8) | buf[3]);
+    gyroData[2] = (int16_t)((buf[4] << 8) | buf[5]);
 }
 
 void mpu6050_read_temperature(int16_t *tempData)

--- a/examples/accelgyro/accelgyro.c
+++ b/examples/accelgyro/accelgyro.c
@@ -22,11 +22,13 @@
 #include <breezystm32.h>
 
 
-uint16_t acc1G;
-float gyroScale;
+float accel_scale; // converts to units of m/s^2
+float gyro_scale; // converts to units of rad/s
+
 int16_t accel_data[3];
 int16_t gyro_data[3];
 int16_t temp_data;
+
 bool mpu_data_ready = false;
 uint32_t mpu_cb_time = 0;
 uint32_t prev_time = 0;
@@ -43,13 +45,14 @@ void setup(void)
     delay(500);
     i2cInit(I2CDEV_2);
     mpu6050_register_interrupt_cb(&interruptCallback);
-    mpu6050_init(true, &acc1G, &gyroScale, 2);
+
+    uint16_t acc1G;
+    mpu6050_init(true, &acc1G, &gyro_scale, 2);
+    accel_scale = 9.80665f / acc1G;
 }
 
 void loop(void)
 {
-    int32_t accel_scale = (1000*9807)/acc1G;
-    float gyro_scale = gyroScale*1000000000.0;
     if (mpu_data_ready)
     {
         mpu_data_ready = false;
@@ -58,14 +61,14 @@ void loop(void)
         mpu6050_read_temperature(&temp_data);
         
         printf("%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\n",
-              ((int32_t)accel_data[0]*accel_scale)/1000, // prints in mm/s^s
-              ((int32_t)accel_data[1]*accel_scale)/1000,
-              ((int32_t)accel_data[2]*accel_scale)/1000,
-              (int32_t)((float)gyro_data[0]*gyro_scale), // prints in mrad/s
-              (int32_t)((float)gyro_data[1]*gyro_scale),
-              (int32_t)((float)gyro_data[2]*gyro_scale),
-              (int32_t)((temp_data/340.0 + 36.53)*1000),
-              mpu_cb_time-prev_time); // the time since the previous IMU measurement was taken in us
+               (int32_t)(accel_data[0]*accel_scale*1000), // prints in mm/s^2
+               (int32_t)(accel_data[1]*accel_scale*1000),
+               (int32_t)(accel_data[2]*accel_scale*1000),
+               (int32_t)(gyro_data[0]*gyro_scale*1000), // prints in mrad/s
+               (int32_t)(gyro_data[1]*gyro_scale*1000),
+               (int32_t)(gyro_data[2]*gyro_scale*1000),
+               (int32_t)((temp_data/340.0f + 36.53f)*1000), // prints in mdegC
+               mpu_cb_time-prev_time); // the time since the previous IMU measurement was taken, in us
     }
     else
     {


### PR DESCRIPTION
Hi @simondlevy, I'm working with @superjax on the [ROSflight2](https://github.com/BYU-MAGICC/ROSflight2) autopilot firmware built on your excellent library.

This pull request fixes a couple of weird things going on with MPU6050 gyro scale factor left over from the baseflight firmware. These are:
- The raw ADC values were confusingly being divided by 4 in the `mpu6050_read_gyro()` function, which was then corrected by adding a factor of 4 to the `gyroScale` value. Got rid of these unnecessary operations.
- There was a weird scaling of `0.000001f` on the `gyroScale` value that would put the measurement into units of Mrad/s. By getting rid of this, multiplying the raw value by `gyroScale` gives the measurement in units of rad/s

I've also updated the accelgyro example to reflect these changes.