### PR TITLE
Async i2c

### DIFF
--- a/drv_i2c.c
+++ b/drv_i2c.c
@@ -596,4 +596,16 @@ void i2c_job_handler()
   free(temp);
 }
 
+uint32_t get_i2c_queue_length()
+{
+  uint32_t count = 0;
+  i2cJob_t* iterator = i2c_job_queue_front;
+  while(iterator != NULL)
+  {
+    count++;
+    iterator = iterator->next_job;
+  }
+  return count;
+}
+
 #endif

--- a/drv_i2c.c
+++ b/drv_i2c.c
@@ -196,70 +196,70 @@ bool i2cRead(uint8_t addr_, uint8_t reg_, uint8_t len, uint8_t *buf)
 
 bool i2cReadAsync(uint8_t addr_, uint8_t reg_, uint8_t len, uint8_t *buf, volatile uint8_t* status_, void (*CB)(void))
 {
-  uint32_t timeout = I2C_DEFAULT_TIMEOUT;
+    uint32_t timeout = I2C_DEFAULT_TIMEOUT;
 
-  addr = addr_ << 1;
-  reg = reg_;
-  writing = 0;
-  reading = 1;
-  read_p = buf;
-  write_p = buf;
-  bytes = len;
-  busy = 1;
-  error = false;
-  status = status_;
-  complete_CB = CB;
-//  (*status) = I2C_JOB_BUSY;
+    addr = addr_ << 1;
+    reg = reg_;
+    writing = 0;
+    reading = 1;
+    read_p = buf;
+    write_p = buf;
+    bytes = len;
+    busy = 1;
+    error = false;
+    status = status_;
+    complete_CB = CB;
+    //  (*status) = I2C_JOB_BUSY;
 
-  if(!I2Cx)
-    return false;
+    if(!I2Cx)
+        return false;
 
-  if (!(I2Cx->CR2 & I2C_IT_EVT)) {                                    // if we are restarting the driver
-      if (!(I2Cx->CR1 & 0x0100)) {                                    // ensure sending a start
-          while (I2Cx->CR1 & 0x0200 && --timeout > 0) {               // This is blocking, but happens only
-              ;    // wait for any stop to finish sending             // if we are stomping on the port (try to avoid)
-          }
-          if (timeout == 0)
-              return i2cHandleHardwareFailure();
-          I2C_GenerateSTART(I2Cx, ENABLE);                            // send the start for the new job
-      }
-      I2C_ITConfig(I2Cx, I2C_IT_EVT | I2C_IT_ERR, ENABLE);            // allow the interrupts to fire off again
-  }
-  return true;
+    if (!(I2Cx->CR2 & I2C_IT_EVT)) {                                    // if we are restarting the driver
+        if (!(I2Cx->CR1 & 0x0100)) {                                    // ensure sending a start
+            while (I2Cx->CR1 & 0x0200 && --timeout > 0) {               // This is blocking, but happens only
+                ;    // wait for any stop to finish sending             // if we are stomping on the port (try to avoid)
+            }
+            if (timeout == 0)
+                return i2cHandleHardwareFailure();
+            I2C_GenerateSTART(I2Cx, ENABLE);                            // send the start for the new job
+        }
+        I2C_ITConfig(I2Cx, I2C_IT_EVT | I2C_IT_ERR, ENABLE);            // allow the interrupts to fire off again
+    }
+    return true;
 }
 
 bool i2cWriteAsync(uint8_t addr_, uint8_t reg_, uint8_t len_, uint8_t *buf_, volatile uint8_t* status_, void (*CB)(void))
 {
-  uint32_t timeout = I2C_DEFAULT_TIMEOUT;
+    uint32_t timeout = I2C_DEFAULT_TIMEOUT;
 
-  addr = addr_ << 1;
-  reg = reg_;
-  writing = 1;
-  reading = 0;
-  write_p = buf_;
-  read_p = buf_;
-  bytes = len_;
-  busy = 1;
-  error = false;
-  status = status_;
-  complete_CB = CB;
-//  (*status) = I2C_JOB_BUSY;
+    addr = addr_ << 1;
+    reg = reg_;
+    writing = 1;
+    reading = 0;
+    write_p = buf_;
+    read_p = buf_;
+    bytes = len_;
+    busy = 1;
+    error = false;
+    status = status_;
+    complete_CB = CB;
+    //  (*status) = I2C_JOB_BUSY;
 
-  if (!I2Cx)
-      return false;
+    if (!I2Cx)
+        return false;
 
-  if (!(I2Cx->CR2 & I2C_IT_EVT)) {                                    // if we are restarting the driver
-      if (!(I2Cx->CR1 & 0x0100)) {                                    // ensure sending a start
-          while (I2Cx->CR1 & 0x0200 && --timeout > 0) {
-              ;    // wait for any stop to finish sending
-          }
-          if (timeout == 0)
-              return i2cHandleHardwareFailure();
-          I2C_GenerateSTART(I2Cx, ENABLE);                            // send the start for the new job
-      }
-      I2C_ITConfig(I2Cx, I2C_IT_EVT | I2C_IT_ERR, ENABLE);            // allow the interrupts to fire off again
-  }
-  return true;
+    if (!(I2Cx->CR2 & I2C_IT_EVT)) {                                    // if we are restarting the driver
+        if (!(I2Cx->CR1 & 0x0100)) {                                    // ensure sending a start
+            while (I2Cx->CR1 & 0x0200 && --timeout > 0) {
+                ;    // wait for any stop to finish sending
+            }
+            if (timeout == 0)
+                return i2cHandleHardwareFailure();
+            I2C_GenerateSTART(I2Cx, ENABLE);                            // send the start for the new job
+        }
+        I2C_ITConfig(I2Cx, I2C_IT_EVT | I2C_IT_ERR, ENABLE);            // allow the interrupts to fire off again
+    }
+    return true;
 }
 
 
@@ -300,7 +300,7 @@ static void i2c_er_handler(void)
 
 void i2c_ev_handler(void)
 {
-//    (*status) = I2C_JOB_COMPLETE;
+    //    (*status) = I2C_JOB_COMPLETE;
     static uint8_t subaddress_sent, final_stop;                         // flag to indicate if subaddess sent, flag to indicate final bus condition
     static int8_t index;                                                // index is signed -1 == send the subaddress
     uint8_t SReg_1 = I2Cx->SR1;                                         // read the status register here
@@ -514,103 +514,103 @@ static void i2cUnstick(void)
 
 void i2c_queue_job(i2cJobType_t type, uint8_t addr_, uint8_t reg_, uint8_t *data, uint8_t length, volatile uint8_t* status_, void (*CB)(void))
 {
-  // create space for the new job
-  i2cJob_t* job = (i2cJob_t*)malloc(sizeof(i2cJob_t));
+    // create space for the new job
+    i2cJob_t* job = (i2cJob_t*)malloc(sizeof(i2cJob_t));
 
-  // save the data about the job
-  job->type = type;
-  job->data = data;
-  job->addr = addr_;
-  job->reg = reg_;
-  job->length = length;
-  job->next_job = NULL;
-  job->status = status_;
-  job->CB = CB;
+    // save the data about the job
+    job->type = type;
+    job->data = data;
+    job->addr = addr_;
+    job->reg = reg_;
+    job->length = length;
+    job->next_job = NULL;
+    job->status = status_;
+    job->CB = CB;
 
-  // change job status
-  (*job->status) = I2C_JOB_QUEUED;
+    // change job status
+    (*job->status) = I2C_JOB_QUEUED;
 
-  if(i2c_job_queue_back == NULL && i2c_job_queue_front == NULL) {
-      // if the job queue is empty, restart it.
-      i2c_job_queue_back = job;
-      i2c_job_queue_front = job;
+    if(i2c_job_queue_back == NULL && i2c_job_queue_front == NULL) {
+        // if the job queue is empty, restart it.
+        i2c_job_queue_back = job;
+        i2c_job_queue_front = job;
 
-      // restart i2c job handling
-      i2c_job_handler();
-  } else {
-      // enque the data, make this newest message the back (FIFO)
-      i2c_job_queue_back->next_job = job;
-      i2c_job_queue_back = job;
-  }
-  return;
+        // restart i2c job handling
+        i2c_job_handler();
+    } else {
+        // enque the data, make this newest message the back (FIFO)
+        i2c_job_queue_back->next_job = job;
+        i2c_job_queue_back = job;
+    }
+    return;
 }
 
 void i2c_job_handler()
 {
-  if(i2c_job_queue_back == NULL && i2c_job_queue_front == NULL)
-  {
-     // the queue is empty, stop performing i2c until
-     // a new job is enqueued
-    return;
-  }
+    if(i2c_job_queue_back == NULL && i2c_job_queue_front == NULL)
+    {
+        // the queue is empty, stop performing i2c until
+        // a new job is enqueued
+        return;
+    }
 
-  if(busy)
-  {
-    // wait for the current job to finish.  This function
-    // will get called again when the job is done
-    return;
-  }
+    if(busy)
+    {
+        // wait for the current job to finish.  This function
+        // will get called again when the job is done
+        return;
+    }
 
-  // Perform the job on the front of the queue
-  // First, change status to BUSY
-  (*i2c_job_queue_front->status) = I2C_JOB_BUSY;
-  if(i2c_job_queue_front->type == READ)
-  {
-    // perform the appropriate job
-    i2cReadAsync(i2c_job_queue_front->addr,
-                 i2c_job_queue_front->reg,
-                 i2c_job_queue_front->length,
-                 i2c_job_queue_front->data,
-                 i2c_job_queue_front->status,
-                 i2c_job_queue_front->CB);
-  }
-  else
-  {
-    i2cWriteAsync(i2c_job_queue_front->addr,
-                 i2c_job_queue_front->reg,
-                 i2c_job_queue_front->length,
-                 i2c_job_queue_front->data,
-                 i2c_job_queue_front->status,
-                 i2c_job_queue_front->CB);
-  }
+    // Perform the job on the front of the queue
+    // First, change status to BUSY
+    (*i2c_job_queue_front->status) = I2C_JOB_BUSY;
+    if(i2c_job_queue_front->type == READ)
+    {
+        // perform the appropriate job
+        i2cReadAsync(i2c_job_queue_front->addr,
+                     i2c_job_queue_front->reg,
+                     i2c_job_queue_front->length,
+                     i2c_job_queue_front->data,
+                     i2c_job_queue_front->status,
+                     i2c_job_queue_front->CB);
+    }
+    else
+    {
+        i2cWriteAsync(i2c_job_queue_front->addr,
+                      i2c_job_queue_front->reg,
+                      i2c_job_queue_front->length,
+                      i2c_job_queue_front->data,
+                      i2c_job_queue_front->status,
+                      i2c_job_queue_front->CB);
+    }
 
-  // Dequeue the job
-  i2cJob_t* temp = i2c_job_queue_front;
-  if(i2c_job_queue_back == i2c_job_queue_front)
-  {
-    // Last job on the queue
-    i2c_job_queue_back = NULL;
-    i2c_job_queue_front = NULL;
-  }
-  else
-  {
-    i2c_job_queue_front = i2c_job_queue_front->next_job;
-  }
+    // Dequeue the job
+    i2cJob_t* temp = i2c_job_queue_front;
+    if(i2c_job_queue_back == i2c_job_queue_front)
+    {
+        // Last job on the queue
+        i2c_job_queue_back = NULL;
+        i2c_job_queue_front = NULL;
+    }
+    else
+    {
+        i2c_job_queue_front = i2c_job_queue_front->next_job;
+    }
 
-  // so we don't have memory leaks, free memory allocated when the job was queued
-  free(temp);
+    // so we don't have memory leaks, free memory allocated when the job was queued
+    free(temp);
 }
 
 uint32_t get_i2c_queue_length()
 {
-  uint32_t count = 0;
-  i2cJob_t* iterator = i2c_job_queue_front;
-  while(iterator != NULL)
-  {
-    count++;
-    iterator = iterator->next_job;
-  }
-  return count;
+    uint32_t count = 0;
+    i2cJob_t* iterator = i2c_job_queue_front;
+    while(iterator != NULL)
+    {
+        count++;
+        iterator = iterator->next_job;
+    }
+    return count;
 }
 
 #endif

--- a/drv_i2c.c
+++ b/drv_i2c.c
@@ -210,7 +210,6 @@ bool i2cReadAsync(uint8_t addr_, uint8_t reg_, uint8_t len, uint8_t *buf, volati
     error = false;
     status = status_;
     complete_CB = CB;
-    //  (*status) = I2C_JOB_BUSY;
 
     if(!I2Cx)
         return false;
@@ -244,7 +243,6 @@ bool i2cWriteAsync(uint8_t addr_, uint8_t reg_, uint8_t len_, uint8_t *buf_, vol
     error = false;
     status = status_;
     complete_CB = CB;
-    //  (*status) = I2C_JOB_BUSY;
 
     if (!I2Cx)
         return false;
@@ -301,7 +299,6 @@ static void i2c_er_handler(void)
 
 void i2c_ev_handler(void)
 {
-    //    (*status) = I2C_JOB_COMPLETE;
     static uint8_t subaddress_sent, final_stop;                         // flag to indicate if subaddess sent, flag to indicate final bus condition
     static int8_t index;                                                // index is signed -1 == send the subaddress
     uint8_t SReg_1 = I2Cx->SR1;                                         // read the status register here

--- a/drv_i2c.h
+++ b/drv_i2c.h
@@ -69,9 +69,9 @@ bool i2cRead(uint8_t addr_, uint8_t reg, uint8_t len, uint8_t *buf);
 // as the blocking versions.
 //
 // There is no checking that the queue length stays within reasonable limits.  Just don't go crazy
-// queunig jobs, because it won't stop you from overflowing the memory
+// queueig jobs, because it won't stop you from overflowing the memory
 //
 // For an example of how to use, check out mpu6050_request_read_temp - the non-blocking way to read
-// the temperometer
+// the accelerometer
 uint32_t get_i2c_queue_length();
 void i2c_queue_job(i2cJobType_t type, uint8_t addr_, uint8_t reg_, uint8_t *data, uint8_t length, volatile uint8_t *status_, void (*CB)(void));

--- a/drv_i2c.h
+++ b/drv_i2c.h
@@ -27,8 +27,41 @@ typedef enum I2CDevice {
     I2CDEV_MAX = I2CDEV_2
 } I2CDevice;
 
+typedef enum {
+  READ,
+  WRITE
+} i2cJobType_t;
+
+enum {
+  I2C_JOB_DEFAULT,
+  I2C_JOB_QUEUED,
+  I2C_JOB_BUSY,
+  I2C_JOB_COMPLETE,
+  I2C_JOB_ERROR
+};
+
+typedef struct i2cJob{
+  i2cJobType_t type;
+  uint8_t addr;
+  uint8_t reg;
+  uint8_t* data;
+  uint8_t length;
+  struct i2cJob* next_job;
+  uint8_t* status;
+} i2cJob_t;
+
+i2cJob_t* i2c_job_queue_front;
+i2cJob_t* i2c_job_queue_back;
+
+bool i2c_queue_job(i2cJobType_t type, uint8_t addr, uint8_t reg, uint8_t *data, uint8_t length, uint8_t* status);
+
+void i2c_job_handler();
+
 void i2cInit(I2CDevice index);
 bool i2cWriteBuffer(uint8_t addr_, uint8_t reg_, uint8_t len_, uint8_t *data);
 bool i2cWrite(uint8_t addr_, uint8_t reg, uint8_t data);
 bool i2cRead(uint8_t addr_, uint8_t reg, uint8_t len, uint8_t *buf);
 uint16_t i2cGetErrorCounter(void);
+
+bool i2cReadAsync(uint8_t addr_, uint8_t reg_, uint8_t len, uint8_t *buf, uint8_t* result_flag_);
+bool i2cWriteAsync(uint8_t addr_, uint8_t reg_, uint8_t len, uint8_t *buf, uint8_t* result_flag_);

--- a/drv_i2c.h
+++ b/drv_i2c.h
@@ -71,7 +71,7 @@ bool i2cRead(uint8_t addr_, uint8_t reg, uint8_t len, uint8_t *buf);
 // There is no checking that the queue length stays within reasonable limits.  Just don't go crazy
 // queunig jobs, because it won't stop you from overflowing the memory
 //
-// For an example of how to use, check out mpu6050_request_read_accel - the non-blocking way to read
-// the accelerometer
+// For an example of how to use, check out mpu6050_request_read_temp - the non-blocking way to read
+// the temperometer
 uint32_t get_i2c_queue_length();
 void i2c_queue_job(i2cJobType_t type, uint8_t addr_, uint8_t reg_, uint8_t *data, uint8_t length, volatile uint8_t *status_, void (*CB)(void));

--- a/drv_i2c.h
+++ b/drv_i2c.h
@@ -63,6 +63,7 @@ bool i2cWrite(uint8_t addr_, uint8_t reg, uint8_t data);
 bool i2cRead(uint8_t addr_, uint8_t reg, uint8_t len, uint8_t *buf);
 
 // Asynchronous I2C functions (return false if hardware failure, otherwise return true)
+uint32_t get_i2c_queue_length();
 void i2c_queue_job(i2cJobType_t type, uint8_t addr_, uint8_t reg_, uint8_t *data, uint8_t length, volatile uint8_t *status_, void (*CB)(void));
 void i2c_job_handler();
 bool i2cReadAsync(uint8_t addr_, uint8_t reg_, uint8_t len, uint8_t *buf, volatile uint8_t* status_, void (*CB)(void));

--- a/drv_i2c.h
+++ b/drv_i2c.h
@@ -47,21 +47,23 @@ typedef struct i2cJob{
   uint8_t* data;
   uint8_t length;
   struct i2cJob* next_job;
-  uint8_t* status;
+  volatile uint8_t* status;
+  void (*CB)(void);
 } i2cJob_t;
 
 i2cJob_t* i2c_job_queue_front;
 i2cJob_t* i2c_job_queue_back;
 
-bool i2c_queue_job(i2cJobType_t type, uint8_t addr, uint8_t reg, uint8_t *data, uint8_t length, uint8_t* status);
-
-void i2c_job_handler();
-
 void i2cInit(I2CDevice index);
+uint16_t i2cGetErrorCounter(void);
+
+// Blocking I2C functions (returns value success or failure)
 bool i2cWriteBuffer(uint8_t addr_, uint8_t reg_, uint8_t len_, uint8_t *data);
 bool i2cWrite(uint8_t addr_, uint8_t reg, uint8_t data);
 bool i2cRead(uint8_t addr_, uint8_t reg, uint8_t len, uint8_t *buf);
-uint16_t i2cGetErrorCounter(void);
 
-bool i2cReadAsync(uint8_t addr_, uint8_t reg_, uint8_t len, uint8_t *buf, uint8_t* result_flag_);
-bool i2cWriteAsync(uint8_t addr_, uint8_t reg_, uint8_t len, uint8_t *buf, uint8_t* result_flag_);
+// Asynchronous I2C functions (return false if hardware failure, otherwise return true)
+void i2c_queue_job(i2cJobType_t type, uint8_t addr_, uint8_t reg_, uint8_t *data, uint8_t length, volatile uint8_t *status_, void (*CB)(void));
+void i2c_job_handler();
+bool i2cReadAsync(uint8_t addr_, uint8_t reg_, uint8_t len, uint8_t *buf, volatile uint8_t* status_, void (*CB)(void));
+bool i2cWriteAsync(uint8_t addr_, uint8_t reg_, uint8_t len_, uint8_t *buf_, volatile uint8_t* status_, void (*CB)(void));

--- a/drv_i2c.h
+++ b/drv_i2c.h
@@ -28,27 +28,27 @@ typedef enum I2CDevice {
 } I2CDevice;
 
 typedef enum {
-  READ,
-  WRITE
+    READ,
+    WRITE
 } i2cJobType_t;
 
 enum {
-  I2C_JOB_DEFAULT,
-  I2C_JOB_QUEUED,
-  I2C_JOB_BUSY,
-  I2C_JOB_COMPLETE,
-  I2C_JOB_ERROR
+    I2C_JOB_DEFAULT,
+    I2C_JOB_QUEUED,
+    I2C_JOB_BUSY,
+    I2C_JOB_COMPLETE,
+    I2C_JOB_ERROR
 };
 
 typedef struct i2cJob{
-  i2cJobType_t type;
-  uint8_t addr;
-  uint8_t reg;
-  uint8_t* data;
-  uint8_t length;
-  struct i2cJob* next_job;
-  volatile uint8_t* status;
-  void (*CB)(void);
+    i2cJobType_t type;
+    uint8_t addr;
+    uint8_t reg;
+    uint8_t* data;
+    uint8_t length;
+    struct i2cJob* next_job;
+    volatile uint8_t* status;
+    void (*CB)(void);
 } i2cJob_t;
 
 i2cJob_t* i2c_job_queue_front;
@@ -62,9 +62,16 @@ bool i2cWriteBuffer(uint8_t addr_, uint8_t reg_, uint8_t len_, uint8_t *data);
 bool i2cWrite(uint8_t addr_, uint8_t reg, uint8_t data);
 bool i2cRead(uint8_t addr_, uint8_t reg, uint8_t len, uint8_t *buf);
 
-// Asynchronous I2C functions (return false if hardware failure, otherwise return true)
+// ===================================================================
+// Asynchronous I2C handler
+// To use this, queue up a job, and create a callback you want called when the job is finished
+// You can track progress of the job using the status pointer.  Otherwise, functions the same
+// as the blocking versions.
+//
+// There is no checking that the queue length stays within reasonable limits.  Just don't go crazy
+// queunig jobs, because it won't stop you from overflowing the memory
+//
+// For an example of how to use, check out mpu6050_request_read_accel - the non-blocking way to read
+// the accelerometer
 uint32_t get_i2c_queue_length();
 void i2c_queue_job(i2cJobType_t type, uint8_t addr_, uint8_t reg_, uint8_t *data, uint8_t length, volatile uint8_t *status_, void (*CB)(void));
-void i2c_job_handler();
-bool i2cReadAsync(uint8_t addr_, uint8_t reg_, uint8_t len, uint8_t *buf, volatile uint8_t* status_, void (*CB)(void));
-bool i2cWriteAsync(uint8_t addr_, uint8_t reg_, uint8_t len_, uint8_t *buf_, volatile uint8_t* status_, void (*CB)(void));

--- a/drv_mb1242.h
+++ b/drv_mb1242.h
@@ -34,3 +34,5 @@ typedef struct {
 bool mb1242_init(mb1242_t * mb1242, uint8_t addr);
 
 int32_t mb1242_poll(mb1242_t * mb1242);
+
+void mb1242_request_read(mb1242_t * mb1242, volatile int32-t* sonarData, volatile uint8_t* status);

--- a/drv_mb1242.h
+++ b/drv_mb1242.h
@@ -34,5 +34,3 @@ typedef struct {
 bool mb1242_init(mb1242_t * mb1242, uint8_t addr);
 
 int32_t mb1242_poll(mb1242_t * mb1242);
-
-void mb1242_request_read(mb1242_t * mb1242, volatile int32-t* sonarData, volatile uint8_t* status);

--- a/drv_mpu6050.c
+++ b/drv_mpu6050.c
@@ -284,6 +284,29 @@ void mpu6050_read_temperature(int16_t *tempData)
     *tempData = (int16_t)((buf[0] << 8) | buf[1]) / 4;
 }
 
+static uint8_t accel_buffer[6];
+static volatile int16_t* accel_data;
+
+void mpu6050_request_accel_read(int16_t *accData, uint8_t* status)
+{
+  accel_data = accData;
+  (*status) = I2C_JOB_QUEUED;
+//  static int32_t count = 0;
+//  if(count > 1000)
+//  {
+//    LED1_TOGGLE;
+//    count = 0;
+//  }
+//  count++;
+//  i2c_queue_job(READ,
+//                MPU_ADDRESS,
+//                MPU_RA_ACCEL_XOUT_H,
+//                accel_buffer,
+//                6,
+//                status);
+//  async_accel_read_CB();
+}
+
 void mpu6050_register_interrupt_cb(void (*functionPtr)(void))
 {
   mpuInterruptCallbackPtr = functionPtr;

--- a/drv_mpu6050.c
+++ b/drv_mpu6050.c
@@ -287,7 +287,7 @@ void mpu6050_read_temperature(int16_t *tempData)
 
 /*=======================================================
  * Asynchronous I2C Read Functions:
- * These methods use the asynchronous
+ * These methods use the asynchronous I2C
  * read capability on the naze32.
  */
 

--- a/drv_mpu6050.c
+++ b/drv_mpu6050.c
@@ -284,29 +284,88 @@ void mpu6050_read_temperature(int16_t *tempData)
     *tempData = (int16_t)((buf[0] << 8) | buf[1]) / 4;
 }
 
+
+/*=======================================================
+ * Asynchronous I2C Read Functions:
+ * These methods use the asynchronous
+ * read capability on the naze32.
+ */
+
+// Allocate storage for asynchronous I2C communcation
 static uint8_t accel_buffer[6];
 static volatile int16_t* accel_data;
 
-void mpu6050_request_accel_read(int16_t *accData, uint8_t* status)
+// This function is called when the I2C job is finished
+void accel_read_CB(void)
 {
-  accel_data = accData;
-  (*status) = I2C_JOB_QUEUED;
-//  static int32_t count = 0;
-//  if(count > 1000)
-//  {
-//    LED1_TOGGLE;
-//    count = 0;
-//  }
-//  count++;
-//  i2c_queue_job(READ,
-//                MPU_ADDRESS,
-//                MPU_RA_ACCEL_XOUT_H,
-//                accel_buffer,
-//                6,
-//                status);
-//  async_accel_read_CB();
+  accel_data[0] = (int16_t)((accel_buffer[0] << 8) | accel_buffer[1]);
+  accel_data[1] = (int16_t)((accel_buffer[2] << 8) | accel_buffer[3]);
+  accel_data[2] = (int16_t)((accel_buffer[4] << 8) | accel_buffer[5]);
 }
 
+void mpu6050_request_accel_read(int16_t *accData, volatile uint8_t *status)
+{
+  accel_data = accData;
+  // Adds a new i2c job to the I2C job queue.
+  // Current status of the job can be read by polling the
+  // status variable, and the callback will be called when the function
+  // is finished
+  i2c_queue_job(READ,
+                MPU_ADDRESS,
+                MPU_RA_ACCEL_XOUT_H,
+                accel_buffer,
+                6,
+                status,
+                &accel_read_CB);
+}
+
+
+static uint8_t gyro_buffer[6];
+static volatile int16_t* gyro_data;
+void gyro_read_CB(void)
+{
+  gyro_data[0] = (int16_t)((gyro_buffer[0] << 8) | gyro_buffer[1]);
+  gyro_data[1] = (int16_t)((gyro_buffer[2] << 8) | gyro_buffer[3]);
+  gyro_data[2] = (int16_t)((gyro_buffer[4] << 8) | gyro_buffer[5]);
+}
+
+void mpu6050_request_gyro_read(int16_t *gyroData, uint8_t *status)
+{
+  gyro_data = gyroData;
+  i2c_queue_job(READ,
+                MPU_ADDRESS,
+                MPU_RA_ACCEL_XOUT_H,
+                gyro_buffer,
+                6,
+                status,
+                &accel_read_CB);
+}
+
+static uint8_t temp_buffer[2];
+static volatile int16_t* temp_data;
+void temp_read_CB(void)
+{
+  (*temp_data) = (int16_t)((temp_buffer[0] << 8)| temp_buffer[1])/4;
+}
+
+void mpu6050_request_temp_read(int16_t *tempData, uint8_t *status)
+{
+  temp_data = tempData;
+  i2c_queue_job(READ,
+                MPU_ADDRESS,
+                MPU_RA_ACCEL_XOUT_H,
+                temp_buffer,
+                2,
+                status,
+                &temp_read_CB);
+}
+
+
+/*=======================================================
+ * Custom ISR Registration
+ * This method registers a custom interrpt to be
+ * run upon the interrupt pin on the MPU6050 going high
+ */
 void mpu6050_register_interrupt_cb(void (*functionPtr)(void))
 {
   mpuInterruptCallbackPtr = functionPtr;

--- a/drv_mpu6050.c
+++ b/drv_mpu6050.c
@@ -135,9 +135,9 @@ void mpu6050_exti_init(int boardVersion)
     // see src/main/sensors/initializiation.c:85 in the cleanflight source code
     // for their version handling.
     if (boardVersion > 4) {
-      gpioExtiLineConfig(GPIO_PortSourceGPIOC, GPIO_PinSource13);
+        gpioExtiLineConfig(GPIO_PortSourceGPIOC, GPIO_PinSource13);
     } else {
-      gpioExtiLineConfig(GPIO_PortSourceGPIOB, GPIO_PinSource13);
+        gpioExtiLineConfig(GPIO_PortSourceGPIOB, GPIO_PinSource13);
     }
 
     // Configure EXTI Line13
@@ -169,7 +169,7 @@ void EXTI15_10_IRQHandler(void)
     {
         if(mpuInterruptCallbackPtr != NULL)
         {
-          mpuInterruptCallbackPtr();
+            mpuInterruptCallbackPtr();
         }
     }
     EXTI_ClearITPendingBit(EXTI_Line13);
@@ -225,9 +225,9 @@ void mpu6050_init(bool enableInterrupt, uint16_t * acc1G, float * gyroScale, int
         gpio.speed = Speed_2MHz;
         gpio.mode = Mode_IN_FLOATING;
         if (boardVersion > 4){
-          gpioInit(GPIOC, &gpio);
+            gpioInit(GPIOC, &gpio);
         } else {
-          gpioInit(GPIOB, &gpio);
+            gpioInit(GPIOB, &gpio);
         }
         mpu6050_exti_init(boardVersion);
     }
@@ -298,25 +298,25 @@ static volatile int16_t* accel_data;
 // This function is called when the I2C job is finished
 void accel_read_CB(void)
 {
-  accel_data[0] = (int16_t)((accel_buffer[0] << 8) | accel_buffer[1]);
-  accel_data[1] = (int16_t)((accel_buffer[2] << 8) | accel_buffer[3]);
-  accel_data[2] = (int16_t)((accel_buffer[4] << 8) | accel_buffer[5]);
+    accel_data[0] = (int16_t)((accel_buffer[0] << 8) | accel_buffer[1]);
+    accel_data[1] = (int16_t)((accel_buffer[2] << 8) | accel_buffer[3]);
+    accel_data[2] = (int16_t)((accel_buffer[4] << 8) | accel_buffer[5]);
 }
 
 void mpu6050_request_accel_read(int16_t *accData, volatile uint8_t *status)
 {
-  accel_data = accData;
-  // Adds a new i2c job to the I2C job queue.
-  // Current status of the job can be read by polling the
-  // status variable, and the callback will be called when the function
-  // is finished
-  i2c_queue_job(READ,
-                MPU_ADDRESS,
-                MPU_RA_ACCEL_XOUT_H,
-                accel_buffer,
-                6,
-                status,
-                &accel_read_CB);
+    accel_data = accData;
+    // Adds a new i2c job to the I2C job queue.
+    // Current status of the job can be read by polling the
+    // status variable, and the callback will be called when the function
+    // is finished
+    i2c_queue_job(READ,
+                  MPU_ADDRESS,
+                  MPU_RA_ACCEL_XOUT_H,
+                  accel_buffer,
+                  6,
+                  status,
+                  &accel_read_CB);
 }
 
 
@@ -324,40 +324,40 @@ static uint8_t gyro_buffer[6];
 static volatile int16_t* gyro_data;
 void gyro_read_CB(void)
 {
-  gyro_data[0] = (int16_t)((gyro_buffer[0] << 8) | gyro_buffer[1]);
-  gyro_data[1] = (int16_t)((gyro_buffer[2] << 8) | gyro_buffer[3]);
-  gyro_data[2] = (int16_t)((gyro_buffer[4] << 8) | gyro_buffer[5]);
+    gyro_data[0] = (int16_t)((gyro_buffer[0] << 8) | gyro_buffer[1]);
+    gyro_data[1] = (int16_t)((gyro_buffer[2] << 8) | gyro_buffer[3]);
+    gyro_data[2] = (int16_t)((gyro_buffer[4] << 8) | gyro_buffer[5]);
 }
 
 void mpu6050_request_gyro_read(int16_t *gyroData, volatile uint8_t *status)
 {
-  gyro_data = gyroData;
-  i2c_queue_job(READ,
-                MPU_ADDRESS,
-                MPU_RA_GYRO_XOUT_H,
-                gyro_buffer,
-                6,
-                status,
-                &gyro_read_CB);
+    gyro_data = gyroData;
+    i2c_queue_job(READ,
+                  MPU_ADDRESS,
+                  MPU_RA_GYRO_XOUT_H,
+                  gyro_buffer,
+                  6,
+                  status,
+                  &gyro_read_CB);
 }
 
 static uint8_t temp_buffer[2];
 static volatile int16_t* temp_data;
 void temp_read_CB(void)
 {
-  (*temp_data) = (int16_t)((temp_buffer[0] << 8)| temp_buffer[1])/4;
+    (*temp_data) = (int16_t)((temp_buffer[0] << 8)| temp_buffer[1])/4;
 }
 
 void mpu6050_request_temp_read(volatile int16_t *tempData, volatile uint8_t *status)
 {
-  temp_data = tempData;
-  i2c_queue_job(READ,
-                MPU_ADDRESS,
-                MPU_RA_TEMP_OUT_A,
-                temp_buffer,
-                2,
-                status,
-                &temp_read_CB);
+    temp_data = tempData;
+    i2c_queue_job(READ,
+                  MPU_ADDRESS,
+                  MPU_RA_TEMP_OUT_A,
+                  temp_buffer,
+                  2,
+                  status,
+                  &temp_read_CB);
 }
 
 
@@ -368,5 +368,5 @@ void mpu6050_request_temp_read(volatile int16_t *tempData, volatile uint8_t *sta
  */
 void mpu6050_register_interrupt_cb(void (*functionPtr)(void))
 {
-  mpuInterruptCallbackPtr = functionPtr;
+    mpuInterruptCallbackPtr = functionPtr;
 }

--- a/drv_mpu6050.c
+++ b/drv_mpu6050.c
@@ -329,16 +329,16 @@ void gyro_read_CB(void)
   gyro_data[2] = (int16_t)((gyro_buffer[4] << 8) | gyro_buffer[5]);
 }
 
-void mpu6050_request_gyro_read(int16_t *gyroData, uint8_t *status)
+void mpu6050_request_gyro_read(int16_t *gyroData, volatile uint8_t *status)
 {
   gyro_data = gyroData;
   i2c_queue_job(READ,
                 MPU_ADDRESS,
-                MPU_RA_ACCEL_XOUT_H,
+                MPU_RA_GYRO_XOUT_H,
                 gyro_buffer,
                 6,
                 status,
-                &accel_read_CB);
+                &gyro_read_CB);
 }
 
 static uint8_t temp_buffer[2];
@@ -348,7 +348,7 @@ void temp_read_CB(void)
   (*temp_data) = (int16_t)((temp_buffer[0] << 8)| temp_buffer[1])/4;
 }
 
-void mpu6050_request_temp_read(int16_t *tempData, uint8_t *status)
+void mpu6050_request_temp_read(volatile int16_t *tempData, volatile uint8_t *status)
 {
   temp_data = tempData;
   i2c_queue_job(READ,

--- a/drv_mpu6050.c
+++ b/drv_mpu6050.c
@@ -353,7 +353,7 @@ void mpu6050_request_temp_read(volatile int16_t *tempData, volatile uint8_t *sta
   temp_data = tempData;
   i2c_queue_job(READ,
                 MPU_ADDRESS,
-                MPU_RA_ACCEL_XOUT_H,
+                MPU_RA_TEMP_OUT_A,
                 temp_buffer,
                 2,
                 status,

--- a/drv_mpu6050.h
+++ b/drv_mpu6050.h
@@ -19,13 +19,20 @@
    along with BreezySTM32.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+//#include "drv_i2c.h"
+
 #pragma once
 
-extern volatile bool mpuDataReady;
-extern volatile uint32_t mpuMeasurementTime;
 
 void mpu6050_init(bool enableInterrupt, uint16_t * acc1G, float * gyroScale, int boardVersion);
 void mpu6050_register_interrupt_cb(void (*functionPtr)(void));
+
+// Blocking Read Functions
 void mpu6050_read_accel(int16_t *accData);
 void mpu6050_read_gyro(int16_t *gyroData);
 void mpu6050_read_temperature(int16_t * tempData);
+
+// Asynchronous Read Functions
+void mpu6050_request_accel_read(int16_t *accData, uint8_t *status_);
+void mpu6050_request_gyro_read(int16_t *gyroData, uint8_t *status_);
+void mpu6050_request_temp_read(int16_t * tempData, uint8_t *status_);

--- a/drv_mpu6050.h
+++ b/drv_mpu6050.h
@@ -34,5 +34,5 @@ void mpu6050_read_temperature(int16_t * tempData);
 
 // Asynchronous Read Functions
 void mpu6050_request_accel_read(int16_t *accData, volatile uint8_t *status_);
-void mpu6050_request_gyro_read(int16_t *gyroData, uint8_t *status_);
-void mpu6050_request_temp_read(int16_t * tempData, uint8_t *status_);
+void mpu6050_request_gyro_read(int16_t *gyroData, volatile uint8_t *status_);
+void mpu6050_request_temp_read(volatile int16_t *tempData, volatile uint8_t *status_);

--- a/drv_mpu6050.h
+++ b/drv_mpu6050.h
@@ -19,7 +19,7 @@
    along with BreezySTM32.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-//#include "drv_i2c.h"
+#include "drv_i2c.h"
 
 #pragma once
 
@@ -33,6 +33,6 @@ void mpu6050_read_gyro(int16_t *gyroData);
 void mpu6050_read_temperature(int16_t * tempData);
 
 // Asynchronous Read Functions
-void mpu6050_request_accel_read(int16_t *accData, uint8_t *status_);
+void mpu6050_request_accel_read(int16_t *accData, volatile uint8_t *status_);
 void mpu6050_request_gyro_read(int16_t *gyroData, uint8_t *status_);
 void mpu6050_request_temp_read(int16_t * tempData, uint8_t *status_);

--- a/examples/accelgyro/Makefile
+++ b/examples/accelgyro/Makefile
@@ -154,8 +154,8 @@ clean:
 	rm -rf $(TARGET_HEX) $(TARGET_ELF) $(TARGET_OBJS) $(TARGET_MAP) obj
 
 flash_$(TARGET): $(TARGET_HEX)
-	stty -F $(SERIAL_DEVICE) raw speed 115200 -crtscts cs8 -parenb -cstopb -ixon
-	stm32flash -w $(TARGET_HEX) -v -g 0x0 -b 115200 $(SERIAL_DEVICE)
+	stty -F $(SERIAL_DEVICE) raw speed 921600 -crtscts cs8 -parenb -cstopb -ixon
+	stm32flash -w $(TARGET_HEX) -v -g 0x0 -b 921600 $(SERIAL_DEVICE)
 
 flash: flash_$(TARGET)
 

--- a/examples/accelgyro/accelgyro.c
+++ b/examples/accelgyro/accelgyro.c
@@ -21,9 +21,6 @@
 
 #include <breezystm32.h>
 
-//#include "drv_mpu6050.h"
-
-
 float accel_scale; // converts to units of m/s^2
 float gyro_scale; // converts to units of rad/s
 
@@ -36,18 +33,13 @@ volatile uint8_t gyro_status = 0;
 volatile uint8_t temp_status = 0;
 volatile bool mpu_new_measurement = false;
 
-//void test(uint8_t *status_)
-//{
-//  (*status_) = I2C_JOB_COMPLETE;
-//}
-
 void interruptCallback(void)
 {
   mpu_new_measurement = true;
 
-  //  mpu6050_request_accel_read(accel_data, &accel_status);
+  mpu6050_request_accel_read(accel_data, &accel_status);
   mpu6050_request_gyro_read(gyro_data, &gyro_status);
-  //  mpu6050_request_temp_read(&temp_data, &temp_status);
+  mpu6050_request_temp_read(&temp_data, &temp_status);
 }
 
 uint32_t start_time = 0;
@@ -59,44 +51,29 @@ void setup(void)
   mpu6050_register_interrupt_cb(&interruptCallback);
 
   uint16_t acc1G;
-  mpu6050_init(true, &acc1G, &gyro_scale, 5);
+  mpu6050_init(true, &acc1G, &gyro_scale, 2);
   accel_scale = 9.80665f / acc1G;
 }
 
 void loop(void)
 {
-  if (gyro_status == I2C_JOB_COMPLETE)
-    //        && gyro_status == I2C_JOB_COMPLETE)
-    //        && temp_status == I2C_JOB_COMPLETE)
-    //    {
-    LED0_ON;
-  static int32_t count = 0;
-  static bool on = 0;
-  if(count > 100000)
+  if (accel_status == I2C_JOB_COMPLETE
+      && gyro_status == I2C_JOB_COMPLETE
+      && temp_status == I2C_JOB_COMPLETE)
   {
-    on = !on;
-    count = 0;
-    printf("%d:\t %d\t %d\t %d\t \n", //%d\t %d\t %d\t %d\t \n",
-           get_i2c_queue_length(),
-           //               4,
-           //           (int32_t)(accel_data[0]*accel_scale*1000.0f),
-           //        (int32_t)(accel_data[1]*accel_scale*1000.0f),
-           //        (int32_t)(accel_data[2]*accel_scale*1000.0f));
-           (int32_t)(gyro_data[0]*gyro_scale*1000.0f),
-           (int32_t)(gyro_data[1]*gyro_scale*1000.0f),
-           (int32_t)(gyro_data[2]*gyro_scale*1000.0f));
-        //               temp_data);
+    static int32_t count = 0;
+    if(count > 10000)
+    {
+      count = 0;
+      printf("%d\t %d\t %d\t %d\t %d\t %d\t %d\t \n",
+             (int32_t)(accel_data[0]*accel_scale*1000.0f),
+             (int32_t)(accel_data[1]*accel_scale*1000.0f),
+             (int32_t)(accel_data[2]*accel_scale*1000.0f),
+             (int32_t)(gyro_data[0]*gyro_scale*1000.0f),
+             (int32_t)(gyro_data[1]*gyro_scale*1000.0f),
+             (int32_t)(gyro_data[2]*gyro_scale*1000.0f),
+             temp_data);
+    }
+    count++;
   }
-  if (on){
-    LED1_ON;
-  }else{
-    LED1_OFF;
-  }
-  count++;
-  //    }
-  //    else if (accel_status == I2C_JOB_ERROR)
-  //    {
-  //      LED0_ON;
-  //      LED1_ON;
-  //    }
 }

--- a/examples/accelgyro/accelgyro.c
+++ b/examples/accelgyro/accelgyro.c
@@ -21,6 +21,8 @@
 
 #include <breezystm32.h>
 
+#define BOARD_REV 2
+
 float accel_scale; // converts to units of m/s^2
 float gyro_scale; // converts to units of rad/s
 
@@ -51,7 +53,7 @@ void setup(void)
     mpu6050_register_interrupt_cb(&interruptCallback);
 
     uint16_t acc1G;
-    mpu6050_init(true, &acc1G, &gyro_scale, 2);
+    mpu6050_init(true, &acc1G, &gyro_scale, BOARD_REV);
     accel_scale = 9.80665f / acc1G;
 }
 

--- a/examples/accelgyro/accelgyro.c
+++ b/examples/accelgyro/accelgyro.c
@@ -29,7 +29,7 @@ float gyro_scale; // converts to units of rad/s
 
 int16_t accel_data[3];
 int16_t gyro_data[3];
-int16_t temp_data;
+volatile int16_t temp_data;
 
 volatile uint8_t accel_status = 0;
 volatile uint8_t gyro_status = 0;
@@ -44,85 +44,59 @@ volatile bool mpu_new_measurement = false;
 void interruptCallback(void)
 {
   mpu_new_measurement = true;
-//  mpu6050_request_accel_read(accel_data, &accel_status);
-  mpu6050_request_accel_read(accel_data, &accel_status);
-//  mpu6050_request_gyro_read(gyro_data, &gyro_status);
-//  test(&accel_status);
-//  accel_status = I2C_JOB_COMPLETE;
+
+  //  mpu6050_request_accel_read(accel_data, &accel_status);
+  mpu6050_request_gyro_read(gyro_data, &gyro_status);
+  //  mpu6050_request_temp_read(&temp_data, &temp_status);
 }
 
 uint32_t start_time = 0;
 
 void setup(void)
 {
-    delay(500);
-    i2cInit(I2CDEV_2);
-    mpu6050_register_interrupt_cb(&interruptCallback);
+  delay(500);
+  i2cInit(I2CDEV_2);
+  mpu6050_register_interrupt_cb(&interruptCallback);
 
-    uint16_t acc1G;
-    mpu6050_init(true, &acc1G, &gyro_scale, 5);
-    accel_scale = 9.80665f / acc1G;
+  uint16_t acc1G;
+  mpu6050_init(true, &acc1G, &gyro_scale, 5);
+  accel_scale = 9.80665f / acc1G;
 }
 
 void loop(void)
 {
-//  if(mpu_new_measurement)
-//    accel_status = I2C_JOB_COMPLETE;
-//    interruptCallback();
-//    test(&accel_status);
-    if (accel_status == I2C_JOB_QUEUED)
-    {
-//      LED1_ON;
-//      LED0_OFF;
-    }
-    else if (accel_status == I2C_JOB_BUSY)
-    {
-      LED0_ON;
-      LED1_OFF;
-    }
-    else if (accel_status == I2C_JOB_COMPLETE)
-    {
-      LED0_ON;
-      static int32_t count = 0;
-      static bool on = 0;
-      if(count > 100000)
-      {
-        on = !on;
-        count = 0;
-        printf("%d\t %d\t %d\t \n",
-               accel_data[0],
-               accel_data[1],
-               accel_data[2]);
-      }
-      if(on){
-        LED1_ON;
-      }else{
-        LED1_OFF;
-      }
-      count++;
-    }
-    else if (accel_status == I2C_JOB_ERROR)
-    {
-      LED0_ON;
-      LED1_ON;
-    }
+  if (gyro_status == I2C_JOB_COMPLETE)
+    //        && gyro_status == I2C_JOB_COMPLETE)
+    //        && temp_status == I2C_JOB_COMPLETE)
+    //    {
+    LED0_ON;
+  static int32_t count = 0;
+  static bool on = 0;
+  if(count > 100000)
+  {
+    on = !on;
+    count = 0;
+    printf("%d:\t %d\t %d\t %d\t \n", //%d\t %d\t %d\t %d\t \n",
+           get_i2c_queue_length(),
+           //               4,
+           //           (int32_t)(accel_data[0]*accel_scale*1000.0f),
+           //        (int32_t)(accel_data[1]*accel_scale*1000.0f),
+           //        (int32_t)(accel_data[2]*accel_scale*1000.0f));
+           (int32_t)(gyro_data[0]*gyro_scale*1000.0f),
+           (int32_t)(gyro_data[1]*gyro_scale*1000.0f),
+           (int32_t)(gyro_data[2]*gyro_scale*1000.0f));
+        //               temp_data);
+  }
+  if (on){
+    LED1_ON;
+  }else{
+    LED1_OFF;
+  }
+  count++;
+  //    }
+  //    else if (accel_status == I2C_JOB_ERROR)
+  //    {
+  //      LED0_ON;
+  //      LED1_ON;
+  //    }
 }
-//    if (millis() - start_time > 1000)
-//    {
-//      async_accel_read_CB();
-//      LED0_OFF;
-//    }
-
-//    if(mpu_data_ready)
-//    {
-////        LED1_ON;
-//        mpu_data_ready = false;
-////        printf("%d\t %d\t %d\t %d\t %d\t \n",
-////               (int32_t)(accel_data[0]*accel_scale*1000), // prints in mm/s^2
-////               (int32_t)(accel_data[1]*accel_scale*1000),
-////               (int32_t)(accel_data[2]*accel_scale*1000),
-////               count);
-//        count = 0;
-//        delayMicroseconds(100);
-//    }
-//}

--- a/examples/accelgyro/accelgyro.c
+++ b/examples/accelgyro/accelgyro.c
@@ -35,45 +35,47 @@ volatile bool mpu_new_measurement = false;
 
 void interruptCallback(void)
 {
-  mpu_new_measurement = true;
+    mpu_new_measurement = true;
 
-  mpu6050_request_accel_read(accel_data, &accel_status);
-  mpu6050_request_gyro_read(gyro_data, &gyro_status);
-  mpu6050_request_temp_read(&temp_data, &temp_status);
+    mpu6050_request_accel_read(accel_data, &accel_status);
+    mpu6050_request_gyro_read(gyro_data, &gyro_status);
+    mpu6050_request_temp_read(&temp_data, &temp_status);
 }
 
 uint32_t start_time = 0;
 
 void setup(void)
 {
-  delay(500);
-  i2cInit(I2CDEV_2);
-  mpu6050_register_interrupt_cb(&interruptCallback);
+    delay(500);
+    i2cInit(I2CDEV_2);
+    mpu6050_register_interrupt_cb(&interruptCallback);
 
-  uint16_t acc1G;
-  mpu6050_init(true, &acc1G, &gyro_scale, 2);
-  accel_scale = 9.80665f / acc1G;
+    uint16_t acc1G;
+    mpu6050_init(true, &acc1G, &gyro_scale, 2);
+    accel_scale = 9.80665f / acc1G;
 }
 
 void loop(void)
 {
-  if (accel_status == I2C_JOB_COMPLETE
-      && gyro_status == I2C_JOB_COMPLETE
-      && temp_status == I2C_JOB_COMPLETE)
-  {
-    static int32_t count = 0;
-    if(count > 10000)
+    if (accel_status == I2C_JOB_COMPLETE
+        && gyro_status == I2C_JOB_COMPLETE
+        && temp_status == I2C_JOB_COMPLETE)
     {
-      count = 0;
-      printf("%d\t %d\t %d\t %d\t %d\t %d\t %d\t \n",
-             (int32_t)(accel_data[0]*accel_scale*1000.0f),
-             (int32_t)(accel_data[1]*accel_scale*1000.0f),
-             (int32_t)(accel_data[2]*accel_scale*1000.0f),
-             (int32_t)(gyro_data[0]*gyro_scale*1000.0f),
-             (int32_t)(gyro_data[1]*gyro_scale*1000.0f),
-             (int32_t)(gyro_data[2]*gyro_scale*1000.0f),
-             temp_data);
+        static int32_t count = 0;
+
+        // Throttle printing
+        if(count > 10000)
+        {
+            count = 0;
+            printf("%d\t %d\t %d\t %d\t %d\t %d\t %d\t \n",
+                   (int32_t)(accel_data[0]*accel_scale*1000.0f),
+                    (int32_t)(accel_data[1]*accel_scale*1000.0f),
+                    (int32_t)(accel_data[2]*accel_scale*1000.0f),
+                    (int32_t)(gyro_data[0]*gyro_scale*1000.0f),
+                    (int32_t)(gyro_data[1]*gyro_scale*1000.0f),
+                    (int32_t)(gyro_data[2]*gyro_scale*1000.0f),
+                    temp_data);
+        }
+        count++;
     }
-    count++;
-  }
 }


### PR DESCRIPTION
Hi Simon,

I implemented an asynchronous I2C handler and demonstrated it on a flip32 in the accelgyro example.  It's a bit more complicated, because of the callback references and stuff, but I tried to make it as easy as possible, and tried to comment it up so other people could use it.

I don't know if you were aware of this, but per a discussion I had with @dpkoch, (byu-magicc/ROSflight2#43),  in my experiments, reading I2C on the flip32 takes nearly 600 us!  If during that time I could be doing something else, I might even be able to pull off a Kalman Filter onboard at full rate! At the very least, it would allow me to do a lot more with a simple F1 processor.  It seems weird to me that baseflight and cleanflight both have blocking I2C calls, because it's a big performance hit.

The change is pretty substantial, however.  Let me know if there are any style changes that you would prefer I made.  I have kept all the old blocking calls there, because there are probably quite a bit of older code that wouldn't be compatible with the new asynchronous system.